### PR TITLE
Bump dependencies: Update Bouncy Castle to 1.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## V 2.x.x (NEXT)
 
+## V 2.3.2 Tooling update
+
+* Enh: Bump Bouncy Castle to 1.70 - latest bcprov-jdk15on..
+
 ## V 2.3.1 Tooling update
 
 * Enh: Upgrade tooling and migrate to GitHub Actions.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.xsavikx</groupId>
     <artifactId>bouncy-gpg</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <packaging>jar</packaging>
 
     <name>bouncy-gpg</name>
@@ -65,17 +65,17 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.67</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk15on</artifactId>
-            <version>1.67</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
This is the last `bcprov-jdk15on`-supported version